### PR TITLE
Handle legacy test directory names for old rails projects:

### DIFF
--- a/lib/file-opener.coffee
+++ b/lib/file-opener.coffee
@@ -48,7 +48,7 @@ class FileOpener
       targetFile = path.dirname(@currentFile)
                    .replace(path.join('app', 'views'), path.join('app', 'controllers')) + '_controller.rb'
     else if @isTest(@currentFile)
-      targetFile = @currentFile.replace(path.join('test', 'controllers'), path.join('app', 'controllers'))
+      targetFile = @currentFile.replace(@controllerTestsDirectory(), path.join('app', 'controllers'))
                                .replace(/_test\.rb$/, '.rb')
     else if @isSpec(@currentFile)
       if @currentFile.indexOf('spec/requests') isnt -1
@@ -81,7 +81,7 @@ class FileOpener
                       .replace(resource, "#{pluralize.singular(resource)}.rb")
                       
     else if @isTest(@currentFile)
-      targetFile = @currentFile.replace(path.join('test', 'models'), path.join('app', 'models'))
+      targetFile = @currentFile.replace(@modelTestsDirectory(), path.join('app', 'models'))
                                .replace(/_test\.rb$/, '.rb')
 
     else if @isSpec(@currentFile)
@@ -130,17 +130,17 @@ class FileOpener
   openTest: ->
     @reloadCurrentEditor()
     if @isController(@currentFile)
-      targetFile = @currentFile.replace(path.join('app', 'controllers'), path.join('test', 'controllers'))
+      targetFile = @currentFile.replace(path.join('app', 'controllers'), @controllerTestsDirectory())
                                .replace(/controller\.rb$/, 'controller_test.rb')
     else if @isHelper(@currentFile)
       targetFile = @currentFile.replace(path.join('app', 'helpers'), path.join('test', 'helpers'))
                                .replace(/\.rb$/, '_test.rb')
     else if @isModel(@currentFile)
-      targetFile = @currentFile.replace(path.join('app', 'models'), path.join('test', 'models'))
+      targetFile = @currentFile.replace(path.join('app', 'models'), @modelTestsDirectory())
                                .replace(/\.rb$/, '_test.rb')
     else if @isFactory(@currentFile)
       resource = path.basename(@currentFile.replace(/_test\.rb/, '.rb'), '.rb')
-      targetFile = @currentFile.replace(path.join('test', 'factories'), path.join('test', 'models'))
+      targetFile = @currentFile.replace(path.join('test', 'factories'), @modelTestsDirectory())
                                .replace("#{resource}.rb", "#{pluralize.singular(resource)}_test.rb")
     
                                
@@ -332,3 +332,16 @@ class FileOpener
           
     
           
+
+  controllerTestsDirectory: ->
+    @handleLegacyDirectory('functional', 'controllers')
+
+  modelTestsDirectory: ->
+    @handleLegacyDirectory('unit', 'models')
+
+  handleLegacyDirectory: (legacyDirectory, newDirectory)->
+    legacyDirectory = path.join('test', legacyDirectory)
+    if fs.existsSync path.join(atom.project.getPaths()[0], legacyDirectory)
+      legacyDirectory
+    else
+      path.join('test', newDirectory)


### PR DESCRIPTION
addresses https://github.com/hmatsuda/rails-transporter/issues/73#issuecomment-118868962

* handle ’test/functional’ instead of `test/controllers’
* handle ‘test/unit’ instead of `test/models’

for review @hmatsuda 