### PR TITLE
Add support for opening service object tests/specs

### DIFF
--- a/lib/rails-util.coffee
+++ b/lib/rails-util.coffee
@@ -3,49 +3,49 @@ path = require 'path'
 module.exports =
 class RailsUtil
   isController: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('app', 'controllers')) isnt -1 and
     filePath.search(/_controller\.rb$/) isnt -1
-    
+
   isView: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('app', 'views')) isnt -1
 
   isTest: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('test')) isnt -1 and
     filePath.search(/_test\.rb$/) isnt -1
 
   isSpec: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('spec')) isnt -1 and
     filePath.search(/_spec\.rb$/) isnt -1
-    
+
   isHelper: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('app', 'helpers')) isnt -1 and
     filePath.search(/_helper\.rb$/) isnt -1
 
   isModel: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('app', 'models')) isnt -1 and
     filePath.search(/\.rb$/) isnt -1
-    
+
   isAsset: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('app', 'assets')) isnt -1
-    
+
   isMailer: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('app', 'mailers')) isnt -1 and
     filePath.search(/_mailer\.rb$/) isnt -1
-    
+
   isFactory: (filePath) ->
-    filePath? and 
+    filePath? and
     atom.project.relativize(filePath).indexOf(path.join('spec', 'factories')) isnt -1 and
     filePath.search(/\.rb$/) isnt -1
-    
-    
-    
 
-    
+  isService: (filePath) ->
+    filePath? and
+    atom.project.relativize(filePath).search(RegExp(path.join('app', '\\w+'))) isnt -1 and
+    filePath.search(/\.rb$/) isnt -1

--- a/spec/fixtures/app/services/blog_post_analytics.rb
+++ b/spec/fixtures/app/services/blog_post_analytics.rb
@@ -1,0 +1,9 @@
+class BlogPostAnalytics
+  def initialize(post)
+    @post = post
+  end
+
+  def run
+    AnalyticsService.register_pageview(@post.url)
+  end
+end

--- a/spec/fixtures/app/workers/blog_post_analytics_worker.rb
+++ b/spec/fixtures/app/workers/blog_post_analytics_worker.rb
@@ -1,0 +1,9 @@
+class BlogPostAnalyticsWorker
+  def initialize(post)
+    @post = post
+  end
+
+  def run
+    BlogPostAnalytics.new(@post).run
+  end
+end

--- a/spec/fixtures/spec/services/blog_post_analytics_spec.rb
+++ b/spec/fixtures/spec/services/blog_post_analytics_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe BlogPostAnalytics do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/fixtures/spec/workers/blog_post_analytics_worker_spec.rb
+++ b/spec/fixtures/spec/workers/blog_post_analytics_worker_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe BlogPostAnalyticsWorker do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/fixtures/test/services/blog_post_analytics_test.rb
+++ b/spec/fixtures/test/services/blog_post_analytics_test.rb
@@ -1,0 +1,5 @@
+require "test_helper"
+
+describe BlogPostAnalytics do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/fixtures/test/workers/blog_post_analytics_worker_test.rb
+++ b/spec/fixtures/test/workers/blog_post_analytics_worker_test.rb
@@ -1,0 +1,5 @@
+require 'test_helper'
+
+describe BlogPostAnalyticsWorker do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails-transporter-spec.coffee
+++ b/spec/rails-transporter-spec.coffee
@@ -18,76 +18,76 @@ describe "RailsTransporter", ->
     fixturesPath = atom.project.getPaths()[0]
     wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
     atom.project.setPaths([tempPath])
-    
+
     workspaceElement = atom.views.getView(atom.workspace)
     activationPromise = atom.packages.activatePackage('rails-transporter')
-    
+
   describe "open-migration-finder behavior", ->
     describe "when the rails-transporter:open-migration-finder event is triggered", ->
       # it "shows the MigrationFinder or hides it if it's already showing", ->
-      # 
+      #
       #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-migration-finder'
-      # 
+      #
       #   waitsForPromise ->
       #     activationPromise
-      # 
+      #
       #   runs ->
       #     expect(workspaceElement.querySelector('.select-list')).toExist()
-  
+
       it "shows all migration paths and selects the first", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-migration-finder'
-  
+
         waitsForPromise ->
           activationPromise
-  
+
         runs ->
           migrationDir = path.join(atom.project.getPaths()[0], 'db', 'migrate')
           expect(workspaceElement.querySelectorAll('.select-list li').length).toBe fs.readdirSync(migrationDir).length
           for migration in fs.readdirSync(migrationDir)
             expect($(workspaceElement).find(".select-list .primary-line:contains(#{migration})")).toExist()
             expect($(workspaceElement).find(".select-list .secondary-line:contains(#{atom.project.relativize(path.join(migrationDir, migration))})")).toExist()
-          
+
           # expect(workspaceElement.querySelector(".select-list li")).toHaveClass 'two-lines selected'
-  
+
   describe "open-view behavior", ->
     describe "when active editor opens controller", ->
       describe "open file", ->
         beforeEach ->
           waitsForPromise ->
             atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-      
+
         it "opens related view", ->
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(9, 0)
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-view'
-      
+
           # Waits until package is activated and active panes count is 2
           waitsFor ->
             activationPromise
             atom.workspace.getActivePane().getItems().length == 2
-      
+
           runs ->
             viewPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', 'index.html.erb')
             editor = atom.workspace.getActiveTextEditor()
             expect(editor.getPath()).toBe viewPath
             expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^<h1>Listing blogs<\/h1>$/
-            
+
       describe "open file for fallbacks", ->
         beforeEach ->
           waitsForPromise ->
             atom.config.set('rails-transporter.viewFileExtension', ['json.jbuilder'])
             atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'api', 'blogs_controller.rb'))
-      
+
         it "opens related view", ->
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(4, 0)
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-view'
-      
+
           # Waits until package is activated and active panes count is 2
           waitsFor ->
             activationPromise
             atom.workspace.getActivePane().getItems().length == 2
-      
+
           runs ->
             viewPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'api', 'blogs', 'index.json.jbuilder')
             editor = atom.workspace.getActiveTextEditor()
@@ -96,131 +96,131 @@ describe "RailsTransporter", ->
 
 
   describe "open-view-finder behavior", ->
-  
+
     describe "when active editor opens controller", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-    
+
       describe "when the rails-transporter:open-view-finder event is triggered", ->
         # it "shows the ViewFinder or hides it if it's already showing", ->
         #   expect(workspaceElement.querySelector('.select-list')).not.toExist()
-        # 
+        #
         #   # This is an activation event, triggering it will cause the package to be
         #   # activated.
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     expect(workspaceElement.querySelector('.select-list')).toExist()
         #     atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
         #     expect(workspaceElement.querySelector('.select-list')).not.toExist()
-    
+
         it "shows all relative view paths for the current controller and selects the first", ->
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-    
+
           # Waits until package is activated
           waitsForPromise ->
             activationPromise
-    
+
           runs ->
             viewDir = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs')
             expect($(workspaceElement).find('.select-list li').length).toBe fs.readdirSync(viewDir).length
             for view in fs.readdirSync(viewDir)
               expect($(workspaceElement).find(".select-list .primary-line:contains(#{view})")).toExist()
               expect($(workspaceElement).find(".select-list .secondary-line:contains(#{atom.project.relativize(path.join(viewDir, view))})")).toExist()
-    
+
             expect($(workspaceElement).find(".select-list li:first")).toHaveClass 'two-lines selected'
             # hide view-finder for next test
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-            
+
     describe "when active editor opens mailer", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'mailers', 'notification_mailer.rb'))
-    
+
       describe "when the rails-transporter:open-view-finder event is triggered", ->
         # it "shows the ViewFinder or hides it if it's already showing", ->
         #   expect(workspaceElement.querySelector('.select-list')).not.toExist()
-        # 
+        #
         #   # This is an activation event, triggering it will cause the package to be
         #   # activated.
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     expect(workspaceElement.querySelector('.select-list')).toExist()
         #     atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
         #     expect(workspaceElement.querySelector('.select-list')).not.toExist()
-    
+
         # it "shows all relative view paths for the current controller and selects the first", ->
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     viewDir = path.join(atom.project.getPaths()[0], 'app', 'views', 'notification_mailer')
         #     expect(workspaceElement.querySelectorAll('.select-list li').length).toBe fs.readdirSync(viewDir).length
         #     for view in fs.readdirSync(viewDir)
         #       expect($(workspaceElement).find(".select-list .primary-line:contains(#{view})")).toExist()
         #       expect($(workspaceElement).find(".select-list .secondary-line:contains(#{atom.project.relativize(path.join(viewDir, view))})")).toExist()
-        # 
+        #
         #     expect($(workspaceElement).find(".select-list li:first")).toHaveClass 'two-lines selected'
         #     # hide view-finder for next test
         #     atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-  
+
     describe "when active editor opens model", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb'))
-    
+
       describe "when the rails-transporter:open-view-finder event is triggered", ->
         # it "shows the ViewFinder or hides it if it's already showing", ->
         #   expect(workspaceElement.querySelector('.select-list')).not.toExist()
-        # 
+        #
         #   # This is an activation event, triggering it will cause the package to be
         #   # activated.
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     expect(workspaceElement.querySelector('.select-list')).toExist()
         #     atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
         #     expect(workspaceElement.querySelector('.select-list')).not.toExist()
-    
+
         # it "shows all relative view paths for the current controller and selects the first", ->
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-view-finder'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     viewDir = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs')
         #     expect($(workspaceElement).find('.select-list li').length).toBe fs.readdirSync(viewDir).length
         #     for view in fs.readdirSync(viewDir)
         #       expect($(workspaceElement).find(".select-list .primary-line:contains(#{view})")).toExist()
         #       expect($(workspaceElement).find(".select-list .secondary-line:contains(#{atom.project.relativize(path.join(viewDir, view))})")).toExist()
-        # 
+        #
         #     expect($(workspaceElement).find(".select-list li:first")).toHaveClass 'two-lines selected'
-  
+
   describe "open-model behavior", ->
     describe "when active editor opens model and cursor is on include method", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb'))
-      
+
       it "opens model concern", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(1, 0)
@@ -237,40 +237,20 @@ describe "RailsTransporter", ->
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe concernPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^module Searchable$/
-      
+
     describe "when active editor opens controller", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-    
+
       it "opens related model", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
-        runs ->
-          modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
-          editor = atom.workspace.getActiveTextEditor()
-          editor.setCursorBufferPosition new Point(0, 0)
-          expect(editor.getPath()).toBe modelPath
-          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
-            
-    describe "when active editor opens namespaced controller", ->
-      beforeEach ->
-        waitsForPromise ->
-          atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'admins', 'blogs_controller.rb'))
-    
-      it "opens related model", ->
-        atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
-    
-        # Waits until package is activated and active panes count is 2
-        waitsFor ->
-          activationPromise
-          atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
           editor = atom.workspace.getActiveTextEditor()
@@ -278,122 +258,142 @@ describe "RailsTransporter", ->
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
 
-            
+    describe "when active editor opens namespaced controller", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'admins', 'blogs_controller.rb'))
+
+      it "opens related model", ->
+        atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
+
+        # Waits until package is activated and active panes count is 2
+        waitsFor ->
+          activationPromise
+          atom.workspace.getActivePane().getItems().length == 2
+
+        runs ->
+          modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setCursorBufferPosition new Point(0, 0)
+          expect(editor.getPath()).toBe modelPath
+          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
+
+
    describe "when active editor opens model test", ->
      beforeEach ->
        waitsForPromise ->
          atom.workspace.open(path.join(atom.project.getPaths()[0], 'test', 'models', 'blog_test.rb'))
-   
+
      it "opens related model", ->
        atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
-   
+
        # Waits until package is activated and active panes count is 2
        waitsFor ->
          activationPromise
          atom.workspace.getActivePane().getItems().length == 2
-   
+
        runs ->
          modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
          editor = atom.workspace.getActiveTextEditor()
          editor.setCursorBufferPosition new Point(0, 0)
          expect(editor.getPath()).toBe modelPath
          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
- 
+
     describe "when active editor opens model spec", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'models', 'blog_spec.rb'))
-    
+
       it "opens related model", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
-            
+
     describe "when active editor opens factory", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'factories', 'blogs.rb'))
-    
+
       it "opens related model", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
-    
-            
+
+
     describe "when active editor opens view", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', 'show.html.erb'))
-  
+
       it "opens related model", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-model'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class Blog < ActiveRecord::Base$/
-  
+
   describe "open-helper behavior", ->
     describe "when active editor opens controller", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-    
+
       it "opens related helper", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-helper'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           helperPath = path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe helperPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^module BlogsHelper$/
-  
+
     describe "when active editor opens helper test", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'test', 'helpers', 'blogs_helper_test.rb'))
-    
+
       it "opens related helper", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-helper'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           helperPath = path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb')
           editor = atom.workspace.getActiveTextEditor()
@@ -405,674 +405,750 @@ describe "RailsTransporter", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'helpers', 'blogs_helper_spec.rb'))
-    
+
       it "opens related helper", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-helper'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           helperPath = path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe helperPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^module BlogsHelper$/
-  
+
     describe "when active editor opens model", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb'))
-    
+
       it "opens related helper", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-helper'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           helperPath = path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe helperPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^module BlogsHelper$/
-  
+
     describe "when active editor opens view", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', 'show.html.erb'))
-  
+
       it "opens related helper", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-helper'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           helperPath = path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe helperPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^module BlogsHelper$/
-  
-  describe "open-patial-template behavior", ->
+
+  describe "open-partial-template behavior", ->
     beforeEach ->
       waitsForPromise ->
         atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', 'edit.html.erb'))
-  
+
     describe "when cursor's current buffer row contains render method", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(2, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form Partial$/
-  
+
     describe "when cursor's current buffer row contains render method with ':partial =>'", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(3, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form Partial$/
-  
+
     describe "when cursor's current buffer row contains render method with 'partial:'", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(4, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form Partial$/
-  
+
     describe "when cursor's current buffer row contains render method taking shared partial", ->
       it "opens shared partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(5, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'shared', '_form.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Shared Form Partial$/
-  
+
     describe "when current line is to call render method with integer", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(6, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form02.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form02 Partial$/
-          
+
     describe "when current line is to call render method with integer and including ':partial =>'", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(7, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form02.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form02 Partial$/
-  
+
     describe "when current line is to call render method with integer and including '(:partial =>'", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(8, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form02.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form02 Partial$/
-          
+
     describe "when current line is to call render method with '(", ->
       it "opens partial template", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(9, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-partial-template'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', '_form02.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^Form02 Partial$/
-  
+
   describe "open-layout", ->
     describe "when cursor's current buffer row contains layout method", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-  
+
       it "opens specified layout", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(2, 0)
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-layout'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'layouts', 'special.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(3, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /Special Layout/
-          
+
     describe "when same base name as the controller exists", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'top_controller.rb'))
-  
+
       it "opens layout that same base name as the controller", ->
         editor = atom.workspace.getActiveTextEditor()
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-layout'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'layouts', 'top.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(3, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /Top Layout/
-          
+
     describe "when there is no such controller-specific layout", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'main_controller.rb'))
-  
+
       it "opens default layout named 'application'", ->
         editor = atom.workspace.getActiveTextEditor()
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-layout'
-  
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-  
+
         runs ->
           partialPath = path.join(atom.project.getPaths()[0], 'app', 'views', 'layouts', 'application.html.erb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(3, 0)
           expect(editor.getPath()).toBe partialPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /Application Layout/
-  
-  
+
+
   describe "open-spec behavior", ->
     describe "when active editor opens controller", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-  
+
       it "opens controller spec", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
-  
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           specPath = path.join(atom.project.getPaths()[0], 'spec', 'controllers', 'blogs_controller_spec.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(20, 0)
           expect(editor.getPath()).toBe specPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogsController/
-      
+
     describe "when active editor opens model", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb'))
-  
+
       it "opens model spec", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
-  
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           specPath = path.join(atom.project.getPaths()[0], 'spec', 'models', 'blog_spec.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(2, 0)
           expect(editor.getPath()).toBe specPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe Blog /
-          
+
     describe "when active editor opens factory", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'factories', 'blogs.rb'))
-  
+
       it "opens model spec", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
-  
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           specPath = path.join(atom.project.getPaths()[0], 'spec', 'models', 'blog_spec.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(2, 0)
           expect(editor.getPath()).toBe specPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe Blog /
-    
+
     describe "when active editor opens helper", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb'))
-  
+
       it "opens helper spec", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
-  
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           specPath = path.join(atom.project.getPaths()[0], 'spec', 'helpers', 'blogs_helper_spec.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(12, 0)
           expect(editor.getPath()).toBe specPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogsHelper/
-  
+
+    describe "when active editor opens service object", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'services', 'blog_post_analytics.rb'))
+
+      it "opens service object spec", ->
+        atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
+
+        waitsFor ->
+          activationPromise
+          atom.workspace.getActivePane().getItems().length == 2
+
+        runs ->
+          specPath = path.join(atom.project.getPaths()[0], 'spec', 'services', 'blog_post_analytics_spec.rb')
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setCursorBufferPosition new Point(2, 0)
+          expect(editor.getPath()).toBe specPath
+          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogPostAnalytics /
+
+    describe "when active editor opens worker object", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'workers', 'blog_post_analytics_worker.rb'))
+
+      it "opens worker object spec", ->
+        atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
+
+        waitsFor ->
+          activationPromise
+          atom.workspace.getActivePane().getItems().length == 2
+
+        runs ->
+          specPath = path.join(atom.project.getPaths()[0], 'spec', 'workers', 'blog_post_analytics_worker_spec.rb')
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setCursorBufferPosition new Point(2, 0)
+          expect(editor.getPath()).toBe specPath
+          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogPostAnalyticsWorker /
+
   describe "open-test behavior", ->
     describe "when active editor opens controller", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-    
+
       it "opens controller test", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-test'
-    
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           testPath = path.join(atom.project.getPaths()[0], 'test', 'controllers', 'blogs_controller_test.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(2, 0)
           expect(editor.getPath()).toBe testPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogsController/
-      
+
     describe "when active editor opens model", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb'))
-    
+
       it "opens model test", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-test'
-    
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           testPath = path.join(atom.project.getPaths()[0], 'test', 'models', 'blog_test.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(2, 0)
           expect(editor.getPath()).toBe testPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe Blog /
-          
+
     describe "when active editor opens helper", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'helpers', 'blogs_helper.rb'))
-    
+
       it "opens helper test", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-test'
-    
+
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-          
+
         runs ->
           testPath = path.join(atom.project.getPaths()[0], 'test', 'helpers', 'blogs_helper_test.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(2, 0)
           expect(editor.getPath()).toBe testPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogsHelper/
-  
+
+    describe "when active editor opens service object", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'services', 'blog_post_analytics.rb'))
+
+      it "opens service object test", ->
+        atom.commands.dispatch workspaceElement, 'rails-transporter:open-test'
+
+        waitsFor ->
+          activationPromise
+          atom.workspace.getActivePane().getItems().length == 2
+
+        runs ->
+          specPath = path.join(atom.project.getPaths()[0], 'test', 'services', 'blog_post_analytics_test.rb')
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setCursorBufferPosition new Point(2, 0)
+          expect(editor.getPath()).toBe specPath
+          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogPostAnalytics /
+
+    describe "when active editor opens worker object", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'workers', 'blog_post_analytics_worker.rb'))
+
+      it "opens service object test", ->
+        atom.commands.dispatch workspaceElement, 'rails-transporter:open-test'
+
+        waitsFor ->
+          activationPromise
+          atom.workspace.getActivePane().getItems().length == 2
+
+        runs ->
+          specPath = path.join(atom.project.getPaths()[0], 'test', 'workers', 'blog_post_analytics_worker_test.rb')
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setCursorBufferPosition new Point(2, 0)
+          expect(editor.getPath()).toBe specPath
+          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogPostAnalyticsWorker /
+
   describe "open-asset behavior",  ->
     describe "when active editor opens view", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'views', 'layouts', 'application.html.erb'))
-  
+
       describe "when cursor's current buffer row contains stylesheet_link_tag", ->
         describe "enclosed in parentheses", ->
           it "opens stylesheet", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(10, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'application.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(10, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /require_self$/
-  
+
         describe "unenclosed in parentheses", ->
           it "opens stylesheet", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(11, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'application.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(11, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /require_tree/
-        
+
         describe "when source includes slash", ->
           it "opens stylesheet", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(12, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'application02', 'common.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(1, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /require_self/
-        
+
         describe "when source is located in vendor directory", ->
           it "opens stylesheet in vendor directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(13, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'vendor', 'assets', 'stylesheets', 'jquery.popular_style.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /it's popular scss file$/
-        
+
         describe "when source is located in lib directory", ->
           it "opens stylesheet in lib directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(16, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'lib', 'assets', 'stylesheets', 'my_style.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /it's my scss file$/
-  
+
         describe "when source is located in public directory", ->
           it "opens stylesheet in public directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(14, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'public', 'no_asset_pipeline.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's css in public directory$/
-            
+
       describe "when cursor's current buffer row contains javascript_include_tag", ->
         describe "enclosed in parentheses", ->
           it "opens javascript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(5, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'application01.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(12, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/= require jquery$/
-      
+
         describe "unenclosed in parentheses", ->
           it "opens javascript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(6, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'application01.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(12, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/= require jquery$/
-  
+
         describe "when source includes slash", ->
           it "opens javascript in another directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(7, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'application02', 'common.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/= require jquery$/
-              
+
         describe "when source is located in vendor directory", ->
           it "opens javascript in vendor directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(8, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'vendor', 'assets', 'javascripts', 'jquery.popular_library.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's popular library$/
-  
+
         describe "when source is located in lib directory", ->
           it "opens javascript in lib directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(15, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'lib', 'assets', 'javascripts', 'my_library.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's my library$/
-  
+
         describe "when source is located in public directory", ->
           it "opens javascript in public directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(9, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'public', 'no_asset_pipeline.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's in public directory$/
-            
+
         describe "when source's suffix is .erb", ->
           it "opens .erb javascript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(17, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'dynamic_script.js.coffee.erb')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# \.erb file$/
-  
+
     describe "when active editor opens javascript manifest", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'application01.js'))
-        
+
       describe "cursor's current buffer row contains require_tree", ->
         beforeEach ->
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(15, 0)
-  
+
         # it "shows the AssetFinder or hides it if it's already showing", ->
         #   expect(workspaceElement.querySelector('.select-list')).not.toExist()
-        # 
+        #
         #   # This is an activation event, triggering it will cause the package to be
         #   # activated.
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     expect(workspaceElement.querySelector('.select-list')).toExist()
         #     atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
         #     expect(workspaceElement.querySelector('.select-list')).not.toExist()
-      
+
         it "shows file paths in required directory and its subdirectories and selects the first", ->
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-      
+
           # Waits until package is activated
           waitsForPromise ->
             activationPromise
-      
+
           runs ->
             requireDir = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'shared')
             expect(workspaceElement.querySelectorAll('.select-list li').length).toBe fs.readdirSync(requireDir).length
@@ -1082,354 +1158,354 @@ describe "RailsTransporter", ->
             # file be located subdirectory
             expect($(workspaceElement).find(".select-list .primary-line:contains(subdir.js.coffee)")).toExist()
             expect($(workspaceElement).find(".select-list .secondary-line:contains(#{atom.project.relativize(path.join(requireDir, 'subdir', 'subdir.js.coffee'))})")).toExist()
-      
+
             expect($(workspaceElement).find(".select-list li:first")).toHaveClass 'two-lines selected'
             # hide finder
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
       describe "cursor's current buffer row contains require_directory", ->
         beforeEach ->
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(24, 0)
-      
+
         # it "shows the AssetFinder or hides it if it's already showing", ->
         #   expect(workspaceElement.querySelector('.select-list')).not.toExist()
-        # 
+        #
         #   # This is an activation event, triggering it will cause the package to be
         #   # activated.
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     expect(workspaceElement.querySelector('.select-list')).toExist()
         #     atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
         #     expect(workspaceElement.querySelector('.select-list')).not.toExist()
-      
+
         # it "shows file paths in required directory and selects the first", ->
         #   atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        # 
+        #
         #   # Waits until package is activated
         #   waitsForPromise ->
         #     activationPromise
-        # 
+        #
         #   runs ->
         #     requireDir = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'shared')
         #     filesInDirectory = (file for file in fs.readdirSync(requireDir) when fs.lstatSync(path.join(requireDir, file)).isFile())
-        #     
+        #
         #     expect(workspaceElement.querySelectorAll('.select-list li').length).toBe filesInDirectory.length
         #     for file in filesInDirectory
         #       # file be located directly below
         #       expect($(workspaceElement).find(".select-list .primary-line:contains(#{file})")).toExist()
         #       expect($(workspaceElement).find(".select-list .secondary-line:contains(#{atom.project.relativize(path.join(requireDir, file))})")).toExist()
-        # 
+        #
         #     # expect(workspaceElement.querySelector('.select-list li').length).toBe
         #     expect($(workspaceElement).find(".select-list li:first")).toHaveClass 'two-lines selected'
-        
+
       describe "cursor's current buffer row contains require", ->
         describe "when it requires coffeescript with .js suffix", ->
           it "opens coffeescript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(22, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-          
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-          
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'blogs.js.coffee')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# blogs js$/
-  
+
         describe "when it requires coffeescript with .js.coffee suffix", ->
           it "opens coffeescript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(23, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'blogs.js.coffee')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# blogs js$/
-  
+
         describe "when it requires coffeescript without suffix", ->
           it "opens coffeescript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(16, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'blogs.js.coffee')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# blogs js$/
-              
+
         describe "when it requires javascript without suffix", ->
           it "opens javascript", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(17, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'pure-js-blogs.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# pure blogs js$/
-              
+
         describe "when it requires coffeescript in another directory", ->
           it "opens coffeescript in another directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(18, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'shared', 'common.js.coffee')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# shared coffee$/
-              
+
         describe "when it requires javascript in another directory", ->
           it "opens javascript in another directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(19, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'javascripts', 'shared', 'pure-js-common.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^# shared js$/
-              
+
         describe "when it requires javascript in lib directory", ->
           it "opens javascript in lib directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(20, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'lib', 'assets', 'javascripts', 'my_library.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's my library$/
-  
+
         describe "when it requires javascript in vendor directory", ->
           it "opens javascript in vendor directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(21, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-  
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-  
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'vendor', 'assets', 'javascripts', 'jquery.popular_library.js')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's popular library$/
-  
+
     describe "when active editor opens stylesheet manifest", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'application.css'))
-      
+
       describe "when cursor's current buffer row contains 'require'", ->
         describe "when it requires scss with .css suffix", ->
           it "opens scss", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(12, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'blogs.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's blogs.css$/
-  
+
         describe "when it requires scss with .css.scss suffix", ->
           it "opens scss", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(13, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'blogs.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's blogs.css$/
-        
+
         describe "when it requires css without suffix", ->
           it "opens css", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(14, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'pure-css-blogs.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's pure css$/
-        
+
         describe "when it requires scss without suffix", ->
           it "opens scss", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(15, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'blogs.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's blogs.css$/
-        
+
         describe "when it requires scss in another directory", ->
           it "opens scss in another directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(16, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'shared', 'pure-css-common.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's pure css$/
-        
+
         describe "when it requires css in another directory", ->
           it "opens css in another directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(17, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'app', 'assets', 'stylesheets', 'shared', 'common.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's scss$/
-        
+
         describe "when it requires scss in lib directory", ->
           it "opens scss in lib directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(18, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'lib', 'assets', 'stylesheets', 'my_style.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's my scss file$/
-        
+
         describe "when it requires css in lib directory", ->
           it "opens css in lib directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(19, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'lib', 'assets', 'stylesheets', 'pure_css_my_style.css')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's my css file$/
-  
+
         describe "when it requires scss in vendor directory", ->
           it "opens scss in vendor directory", ->
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(20, 0)
             atom.commands.dispatch workspaceElement, 'rails-transporter:open-asset'
-        
+
             waitsFor ->
               activationPromise
               atom.workspace.getActivePane().getItems().length == 2
-        
+
             runs ->
               assetPath = path.join(atom.project.getPaths()[0], 'vendor', 'assets', 'stylesheets', 'jquery.popular_style.css.scss')
               editor = atom.workspace.getActiveTextEditor()
               editor.setCursorBufferPosition new Point(0, 0)
               expect(editor.getPath()).toBe assetPath
               expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^\/\/ it's popular scss file$/
-  
+
   describe "open-controller behavior", ->
     describe "when active editor opens controller and cursor is on include method", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb'))
-      
+
       it "opens model concern", ->
         editor = atom.workspace.getActiveTextEditor()
         editor.setCursorBufferPosition new Point(3, 0)
@@ -1446,40 +1522,40 @@ describe "RailsTransporter", ->
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe concernPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^module Blog::Taggable$/
-  
+
     describe "when active editor opens model", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app/models/blog.rb'))
-    
+
       it "opens related controller", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-controller'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class BlogsController < ApplicationController$/
-  
+
     describe "when active editor opens controller test", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'test', 'controllers', 'blogs_controller_test.rb'))
-    
+
       it "opens related controller", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-controller'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb')
           editor = atom.workspace.getActiveTextEditor()
@@ -1491,55 +1567,55 @@ describe "RailsTransporter", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'controllers', 'blogs_controller_spec.rb'))
-    
+
       it "opens related controller", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-controller'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class BlogsController < ApplicationController$/
-            
+
     describe "when active editor opens request spec", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'requests', 'blogs_spec.rb'))
-    
+
       it "opens related controller", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-controller'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb')
           editor = atom.workspace.getActiveTextEditor()
           editor.setCursorBufferPosition new Point(0, 0)
           expect(editor.getPath()).toBe modelPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^class BlogsController < ApplicationController$/
-            
+
     describe "when active editor opens view", ->
       beforeEach ->
         waitsForPromise ->
           atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'views', 'blogs', 'show.html.haml'))
-    
+
       it "opens related controller", ->
         atom.commands.dispatch workspaceElement, 'rails-transporter:open-controller'
-    
+
         # Waits until package is activated and active panes count is 2
         waitsFor ->
           activationPromise
           atom.workspace.getActivePane().getItems().length == 2
-    
+
         runs ->
           modelPath = path.join(atom.project.getPaths()[0], 'app', 'controllers', 'blogs_controller.rb')
           editor = atom.workspace.getActiveTextEditor()
@@ -1553,35 +1629,35 @@ describe "RailsTransporter", ->
         beforeEach ->
           waitsForPromise ->
             atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'blog.rb'))
-      
+
         it "opens related factory", ->
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-factory'
-      
+
           # Waits until package is activated and active panes count is 2
           waitsFor ->
             activationPromise
             atom.workspace.getActivePane().getItems().length == 2
-      
+
           runs ->
             factoryPath = path.join(atom.project.getPaths()[0], 'spec', 'factories', 'blogs.rb')
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(3, 0)
             expect(editor.getPath()).toBe factoryPath
             expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^  factory :blog, :class => 'Blog' do$/
-          
+
       describe "open singular resource filename", ->
         beforeEach ->
           waitsForPromise ->
             atom.workspace.open(path.join(atom.project.getPaths()[0], 'app', 'models', 'entry.rb'))
-      
+
         it "opens related factory", ->
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-factory'
-      
+
           # Waits until package is activated and active panes count is 2
           waitsFor ->
             activationPromise
             atom.workspace.getActivePane().getItems().length == 2
-      
+
           runs ->
             factoryPath = path.join(atom.project.getPaths()[0], 'spec', 'factories', 'entry.rb')
             editor = atom.workspace.getActiveTextEditor()
@@ -1589,41 +1665,41 @@ describe "RailsTransporter", ->
             expect(editor.getPath()).toBe factoryPath
             expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^  factory :entry, :class => 'Entry' do$/
 
-  
+
     describe "when active editor opens model-spec", ->
       describe "open plural resource filename", ->
         beforeEach ->
           waitsForPromise ->
             atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'models', 'blog_spec.rb'))
-      
+
         it "opens related factory", ->
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-factory'
-      
+
           # Waits until package is activated and active panes count is 2
           waitsFor ->
             activationPromise
             atom.workspace.getActivePane().getItems().length == 2
-      
+
           runs ->
             factoryPath = path.join(atom.project.getPaths()[0], 'spec', 'factories', 'blogs.rb')
             editor = atom.workspace.getActiveTextEditor()
             editor.setCursorBufferPosition new Point(3, 0)
             expect(editor.getPath()).toBe factoryPath
             expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^  factory :blog, :class => 'Blog' do$/
-    
+
       describe "open singular resource filename", ->
         beforeEach ->
           waitsForPromise ->
             atom.workspace.open(path.join(atom.project.getPaths()[0], 'spec', 'models', 'entry_spec.rb'))
-      
+
         it "opens related factory", ->
           atom.commands.dispatch workspaceElement, 'rails-transporter:open-factory'
-      
+
           # Waits until package is activated and active panes count is 2
           waitsFor ->
             activationPromise
             atom.workspace.getActivePane().getItems().length == 2
-      
+
           runs ->
             factoryPath = path.join(atom.project.getPaths()[0], 'spec', 'factories', 'entry.rb')
             editor = atom.workspace.getActiveTextEditor()


### PR DESCRIPTION
Here I'm generalizing everything that follows SRP by calling it a service object, which is technically wrong, but I think it's a decent approximation.

It's pretty common nowadays to have workers/jobs, decorators, services, view objects, etc in Rails applications. So much so that nowadays, Rails, by default, adds `app/*` to the autoload path, so it speaks to the relevance of these objects.

This PR adds a generic support to open specs/tests related to these objects that live under `app/*`. Like all greedy filtering rules, the matching rule for services comes last.

The resulting related file path is generated by replacing `app/<subdir(s)>/<filename>.rb` with `{spec,test}/<subdir(s)>/<filename>_{spec,test}.rb` in the path of the current file.

So, for example, opening related spec/test now works for these cases:

* `app/workers/some_background_job_worker.rb` => `{spec,test}/workers/some_background_job_worker_{spec,test}.rb`
* `app/decorators/some_model_decorator.rb` => `{spec,test}/decorators/some_model_decorator_{spec,test}.rb`
* `app/services/some_domain_logic_service.rb` => `{spec,test}/services/some_domain_logic_service_{spec,test}.rb`