### PR TITLE
Fixes issue #91 - "open spec" (and "open test") proposing wrong directory

### DIFF
--- a/lib/file-opener.coffee
+++ b/lib/file-opener.coffee
@@ -166,7 +166,8 @@ class FileOpener
       targetFile = @currentFile.replace(path.join('test', 'factories'), path.join('test', 'models'))
                                .replace("#{resource}.rb", "#{pluralize.singular(resource)}_test.rb")
     else if @isService(@currentFile)
-      targetFile = @currentFile.replace(RegExp(path.join('app', '(\\w+)')), path.join('test', '$1'))
+      [_, file_path] = atom.project.relativizePath(@currentFile)
+      targetFile = file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('test', '$1'))
                                .replace(/\.rb$/, '_test.rb')
 
 
@@ -203,7 +204,8 @@ class FileOpener
                                .replace("#{resource}.rb", "#{pluralize.singular(resource)}_spec.rb")
 
     else if @isService(@currentFile)
-      targetFile = @currentFile.replace(RegExp(path.join('app', '(\\w+)')), path.join('spec', '$1'))
+      [_, file_path] = atom.project.relativizePath(@currentFile)
+      targetFile = file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('spec', '$1'))
                                .replace(/\.rb$/, '_spec.rb')
 
     if fs.existsSync targetFile

--- a/lib/file-opener.coffee
+++ b/lib/file-opener.coffee
@@ -166,10 +166,9 @@ class FileOpener
       targetFile = @currentFile.replace(path.join('test', 'factories'), path.join('test', 'models'))
                                .replace("#{resource}.rb", "#{pluralize.singular(resource)}_test.rb")
     else if @isService(@currentFile)
-      [_, file_path] = atom.project.relativizePath(@currentFile)
-      targetFile = file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('test', '$1'))
-                               .replace(/\.rb$/, '_test.rb')
-
+      [project_path, file_path] = atom.project.relativizePath(@currentFile)
+      targetFile = path.join(project_path, file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('test', '$1'))
+                               .replace(/\.rb$/, '_test.rb'))
 
     if fs.existsSync targetFile
       @open(targetFile)
@@ -204,9 +203,9 @@ class FileOpener
                                .replace("#{resource}.rb", "#{pluralize.singular(resource)}_spec.rb")
 
     else if @isService(@currentFile)
-      [_, file_path] = atom.project.relativizePath(@currentFile)
-      targetFile = file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('spec', '$1'))
-                               .replace(/\.rb$/, '_spec.rb')
+      [project_path, file_path] = atom.project.relativizePath(@currentFile)
+      targetFile = path.join(project_path, file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('spec', '$1'))
+                               .replace(/\.rb$/, '_spec.rb'))
 
     if fs.existsSync targetFile
       @open(targetFile)


### PR DESCRIPTION
This fixes #91 by taking the relative path from the project folder, instead of the absolute path. That way it doesn't care what the project name is. 

I did not write specs for this, because I believe that it would entail adding another directory to the spec folder with additional fixtures (like "fixturesapp"), which seems a bit heavy handed. Let me know if you want me to do that too or if there's a better way to test it. 

Incidentally, this also fixes the test file name. It was not correctly appending the "_test" suffix to files, so it would suggest the wrong test filename as well.