### PR TITLE
Add config for binding 'lib/' to a specific spec directory.

### DIFF
--- a/lib/file-opener.coffee
+++ b/lib/file-opener.coffee
@@ -207,6 +207,10 @@ class FileOpener
       targetFile = path.join(project_path, file_path.replace(RegExp(path.join('app', '(\\w+)')), path.join('spec', '$1'))
                                .replace(/\.rb$/, '_spec.rb'))
 
+    else if @isLib(@currentFile)
+      libSpecDirectory = atom.config.get('rails-transporter.libSpecDirectory')
+      targetFile = @currentFile.replace(path.join('lib'), path.join('spec', libSpecDirectory)).replace(/\.rb$/, '_spec.rb')
+
     if fs.existsSync targetFile
       @open(targetFile)
     else

--- a/lib/rails-transporter.coffee
+++ b/lib/rails-transporter.coffee
@@ -15,6 +15,10 @@ module.exports =
       description: 'This is the type of the controller spec. controllers, requests or features'
       default:     'controllers'
       enum:        ['controllers', 'requests', 'features', 'api', 'integration']
+    libSpecDirectory:
+      type:        'string'
+      description: 'The subdirectory of "spec/" where specs for files in "lib/" should be searched for.'
+      default:     'framework/lib'
 
   activate: (state) ->
     atom.commands.add 'atom-workspace',

--- a/lib/rails-util.coffee
+++ b/lib/rails-util.coffee
@@ -49,3 +49,8 @@ class RailsUtil
     filePath? and
     atom.project.relativize(filePath).search(RegExp(path.join('app', '\\w+'))) isnt -1 and
     filePath.search(/\.rb$/) isnt -1
+
+  isLib: (filePath) ->
+    filePath? and
+    atom.project.relativize(filePath).search(RegExp(path.join('lib', '\\w+'))) isnt -1 and
+    filePath.search(/\.rb$/) isnt -1

--- a/spec/fixtures/lib/custom_array.rb
+++ b/spec/fixtures/lib/custom_array.rb
@@ -1,0 +1,2 @@
+class CustomArray < Array
+end

--- a/spec/fixtures/spec/framework/lib/custom_array_spec.rb
+++ b/spec/fixtures/spec/framework/lib/custom_array_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe CustomArray do
+  it 'can be initialized' do
+    expect(CustomArray.new).to be_empty
+  end
+end

--- a/spec/rails-transporter-spec.coffee
+++ b/spec/rails-transporter-spec.coffee
@@ -791,6 +791,25 @@ describe "RailsTransporter", ->
           expect(editor.getPath()).toBe specPath
           expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^describe BlogPostAnalyticsWorker /
 
+    describe "when active editor opens lib/ object", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open(path.join(atom.project.getPaths()[0], 'lib', 'custom_array.rb'))
+
+      it "opens lib/ object spec", ->
+        atom.commands.dispatch workspaceElement, 'rails-transporter:open-spec'
+
+        waitsFor ->
+          activationPromise
+          atom.workspace.getActivePane().getItems().length == 2
+
+        runs ->
+          specPath = path.join(atom.project.getPaths()[0], 'spec', 'framework', 'lib', 'custom_array_spec.rb')
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setCursorBufferPosition new Point(2, 0)
+          expect(editor.getPath()).toBe specPath
+          expect(editor.getLastCursor().getCurrentBufferLine()).toMatch /^RSpec\.describe CustomArray /
+
   describe "open-test behavior", ->
     describe "when active editor opens controller", ->
       beforeEach ->


### PR DESCRIPTION
This pull request implements #94.
It adds a config option "rails-transporter.libSpecDirectory" and open-spec handling for files in the "lib/" directory.